### PR TITLE
Insert helm value placeholder for domain

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,14 @@ steps:
 - name: 'gcr.io/cloud-builders/wget'
   args: ['-O', 'knative/templates/knative.yaml', 'https://github.com/knative/serving/releases/download/v0.1.1/release-no-mon.yaml']
 
+# Insert helm placeholders in release manifest
+- name: 'debian:stable-slim'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+        sed -i 's/example.com/{{ .values.domain }}/' knative/templates/knative.yaml
+
 # Initialize Helm without Cluster
 - name: 'gcr.io/triggermesh/helm'
   args: ['init', '--client-only']


### PR DESCRIPTION
There's only one occurence of example.com, in `knative.yaml`'s ConfigMap `config-domain`