### PR TITLE
Introduce a ClusterRole to allow for using knative-serving oustide of cluster-admin

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
         mkdir -p knative/templates
         mv Chart.yaml ./knative
         mv values.yaml ./knative
+        mv knative-cluster-role.yaml ./knative/templates
 
 # Get the Istio manifest
 - name: 'gcr.io/cloud-builders/wget'

--- a/knative-cluster-role.yaml
+++ b/knative-cluster-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-serving-only-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  rules:
+    - apiGroups:
+        - serving.knative.dev
+      resources:
+        - configurations
+        - configurationgenerations
+        - routes
+        - revisions
+        - revisionuids
+        - autoscalers
+        - services
+      verbs:
+        - get
+        - list
+        - create
+        - update
+        - delete
+        - patch
+        - watch


### PR DESCRIPTION
This PR resolves an issue that was raised by a client where they wanted the ability to use Triggermesh's CLI to deploy to a knative cluster, but the service account hosting the pod had the ClusterRole of edit only.

The approach being taken in this case is to define a new, restricted ClusterRole, and allow the edit ClusterRole to inherit the ability to call the knative-serving APIs.