### PR TITLE
Modify index generation to merge current index.yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,11 +49,15 @@ steps:
         mkdir repo
         mv knative-0.2.0.tgz ./repo
 
+# Retrieve the current index
+- name: 'gcr.io/cloud-builders/wget'
+  args: ['-O', './upstream.yaml', 'https://storage.googleapis.com/triggermesh-charts/index.yaml']
+
 # Generate index
 - name: 'gcr.io/triggermesh/helm'
-  args: ['repo', 'index', '--url', 'https://storage.googleapis.com/triggermesh-charts', './repo']
+  args: ['repo', 'index', '--merge', './upstream.yaml', '--url', 'https://storage.googleapis.com/triggermesh-charts', './repo']
 
-# Push index to gcs bucket
+# Push new index to gcs bucket
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp', './repo/index.yaml', 'gs://$PROJECT_ID-charts/index.yaml']
 


### PR DESCRIPTION
Retrieve the current index.yaml file, and "update" it with the newly built binary to ensure that it doesn't clobber prior versions. This will also do the right thing for regenerating newer versions of the same release in case there are issues.

Note that we will probably want to see about passing the knative version as an environment variable or rely on a tag so that we don't need to specify the same version number multiple times.