### PR TITLE
Add an additional ClusterRole  to allow for the edit role to access knative-build endpoints

### DIFF
--- a/knative-cluster-role.yaml
+++ b/knative-cluster-role.yaml
@@ -23,3 +23,25 @@ rules:
   - delete
   - patch
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-build-only-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - build.knative.dev
+  resources:
+  - builds
+  - buildtemplates
+  - clusterbuildtemplates
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch


### PR DESCRIPTION
Observed while working around another issue with the tm client requiring a build template to be specified during service deployment.  The option requires access to knative-build to verify that the template exists, and use it to generate the service yaml that will get uploaded.