### PR TITLE
Version bump for knative 0.2.0 -> 0.2.2, and helm tweaks

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.2.0"
+appVersion: "0.2.2"
 description: A Helm chart for Knative
 name: knative
-version: 0.2.0
+version: 0.2.2

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,11 +12,11 @@ steps:
 
 # Get the Istio manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/v0.2.0/third_party/istio-1.0.2/istio.yaml']
+  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/istio-1.0.2/istio.yaml']
 
 # Get the Knative manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative.yaml', 'https://github.com/knative/serving/releases/download/v0.2.0/release-no-mon.yaml']
+  args: ['-O', 'knative/templates/knative.yaml.base', 'https://github.com/knative/serving/releases/download/v0.2.2/release-no-mon.yaml']
 
 # Templatize the chart
 - name: 'debian:stable-slim'
@@ -24,9 +24,11 @@ steps:
   args:
   - '-c'
   - |
-        sed -i 's/{{/{{ "{{" }}/g' knative/templates/knative.yaml
-        sed -i 's/example.com/{{ .Values.domain }}/' knative/templates/knative.yaml
+        sed -i 's/{{/{{ "{{" }}/g' knative/templates/knative.yaml.base
+        sed -i 's/example.com/{{ .Values.domain }}/' knative/templates/knative.yaml.base
         sed -i 's/LoadBalancer/{{ .Values.istioIngressType }}/' knative/templates/istio.yaml
+        ./fix-knative.pl knative/templates/knative.yaml.base > knative/templates/knative.yaml
+        rm knative/templates/knative.yaml.base
 
 # Initialize Helm without Cluster
 - name: 'gcr.io/triggermesh/helm'
@@ -47,7 +49,7 @@ steps:
   - '-c'
   - |
         mkdir repo
-        mv knative-0.2.0.tgz ./repo
+        mv knative-0.2.2.tgz ./repo
 
 # Retrieve the current index
 - name: 'gcr.io/cloud-builders/wget'
@@ -63,20 +65,20 @@ steps:
 
 # Push it to gcs bucket
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', './repo/knative-0.2.0.tgz', 'gs://$PROJECT_ID-charts/knative-0.2.0.tgz']
+  args: ['cp', './repo/knative-0.2.2.tgz', 'gs://$PROJECT_ID-charts/knative-0.2.2.tgz']
 
 # Build the installer
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.2.0', '-f', './installer/Dockerfile', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', '-f', './installer/Dockerfile', '.']
 
 # Tag and push
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.2.0']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.0', 'gcr.io/$PROJECT_ID/knative-installer:0.2']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', 'gcr.io/$PROJECT_ID/knative-installer:0.2']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.2']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.0', 'gcr.io/$PROJECT_ID/knative-installer:latest']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', 'gcr.io/$PROJECT_ID/knative-installer:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:latest']

--- a/fix-knative.pl
+++ b/fix-knative.pl
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+
+open $YAML, "<", $ARGV[0];
+
+my @components = ();
+my $contents = "";
+
+while (<$YAML>) {
+    if (/---/) {
+        if (length($contents) > 0) {
+            push @components, $contents;
+        }
+        $contents = "";
+    } else {
+        $contents .= $_;
+    }
+}
+close($YAML);
+
+# Strip duplicates
+for (my $i = 0; $i < @components; $i++) {
+    $component = $components[$i];
+
+    for ($j = $i + 1; $j < @components; $j++) {
+        if ($component eq @components[$j]) {
+            splice(@components, $j, 1);
+            $j = $j-1;
+        }
+    }
+}
+
+# Add Helm CRD hooks
+for ($i = 0; $i < @components; $i++) {
+    $component = $components[$i];
+    if ($component =~ m/CustomResourceDefinition/) {
+        $component =~ s/metadata:\n/metadata:\n  annotations:\n    "helm.sh\/hook": crd-install\n/;
+        @components[$i] = $component;
+    }
+
+    print "---\n";
+    print @components[$i];
+}
+
+print "---\n";

--- a/knative-cluster-role.yaml
+++ b/knative-cluster-role.yaml
@@ -23,3 +23,17 @@ rules:
   - delete
   - patch
   - watch
+- apiGroups:
+  - build.knative.dev
+  resources:
+  - builds
+  - buildtemplates
+  - clusterbuildtemplates
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch


### PR DESCRIPTION
Bump the knative version configured from 0.2.0 to 0.2.2. In addition, I am introducing a perl script that will be invoked at least on the knative template to ensure duplicate entries are stripped out and that we add in the helm CRD hooks to ensure they get added before the rest of the file is processed.