### PR TITLE
Version bump 0.2.2 -> 0.3 and add knative-build

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.2.2"
+appVersion: "0.3.0"
 description: A Helm chart for Knative
 name: knative
-version: 0.2.2
+version: 0.3.0

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,11 +12,14 @@ steps:
 
 # Get the Istio manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/istio-1.0.2/istio.yaml']
+  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/v0.3.0/third_party/istio-1.0.2/istio.yaml']
 
-# Get the Knative manifest
+# Get the Knative Build manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative.yaml.base', 'https://github.com/knative/serving/releases/download/v0.2.2/release-no-mon.yaml']
+  args: ['-O', 'knative/templates/knative-build.yaml', 'https://github.com/knative/build/releases/download/v0.3.0/release.yaml']
+# Get the Knative Serving manifest
+- name: 'gcr.io/cloud-builders/wget'
+  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml']
 
 # Templatize the chart
 - name: 'debian:stable-slim'
@@ -24,6 +27,8 @@ steps:
   args:
   - '-c'
   - |
+        cat knative/templates/knative-build.yaml knative/templates/knative-serving.yaml > knative/templates/knative.yaml.base
+        rm knative/templates/knative-build.yaml knative/templates/knative-serving.yaml
         sed -i 's/{{/{{ "{{" }}/g' knative/templates/knative.yaml.base
         sed -i 's/example.com/{{ .Values.domain }}/' knative/templates/knative.yaml.base
         sed -i 's/LoadBalancer/{{ .Values.istioIngressType }}/' knative/templates/istio.yaml
@@ -49,7 +54,7 @@ steps:
   - '-c'
   - |
         mkdir repo
-        mv knative-0.2.2.tgz ./repo
+        mv knative-0.3.0.tgz ./repo
 
 # Retrieve the current index
 - name: 'gcr.io/cloud-builders/wget'
@@ -65,20 +70,20 @@ steps:
 
 # Push it to gcs bucket
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', './repo/knative-0.2.2.tgz', 'gs://$PROJECT_ID-charts/knative-0.2.2.tgz']
+  args: ['cp', './repo/knative-0.3.0.tgz', 'gs://$PROJECT_ID-charts/knative-0.3.0.tgz']
 
 # Build the installer
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', '-f', './installer/Dockerfile', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', '-f', './installer/Dockerfile', '.']
 
 # Tag and push
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', 'gcr.io/$PROJECT_ID/knative-installer:0.2']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', 'gcr.io/$PROJECT_ID/knative-installer:0.3']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.2']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.3']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.2.2', 'gcr.io/$PROJECT_ID/knative-installer:latest']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', 'gcr.io/$PROJECT_ID/knative-installer:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:latest']

--- a/fix-knative.pl
+++ b/fix-knative.pl
@@ -17,6 +17,11 @@ while (<$YAML>) {
 }
 close($YAML);
 
+# Strip multiple newlines
+for (my $i = 0; $i < @components; $i++) {
+    $components[$i] =~ s/\n\n/\n/g;
+}
+
 # Strip duplicates
 for (my $i = 0; $i < @components; $i++) {
     $component = $components[$i];


### PR DESCRIPTION
Bump the Knative helm chart to 0.3.  In addition, there were a few of issues that cropped up:

1. Knative is no longer distributing the `release-no-mon.yaml` file.  Instead they are providing a lone `serving.yaml` file that does not include the monitoring bits.
1. Knative serving has pulled out the `knative-build` component. I suspect this is due to build being deprecated in favor of the tekton pipeline.
1. Due to the extra newline characters in the Knative Build `release.yaml` file, it broke the dedup perl script.