### PR TITLE
Initial conversion 0.3.0 -> 0.4.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.3.0"
+appVersion: "0.4.1"
 description: A Helm chart for Knative
 name: knative
-version: 0.3.0
+version: 0.4.1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,16 +10,21 @@ steps:
         mv values.yaml ./knative
         mv knative-cluster-role.yaml ./knative/templates
 
-# Get the Istio manifest
+# Get the Istio 1.0.7 manifest to resolve CVE-2019-9900 and CVE-2019-9901
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/v0.3.0/third_party/istio-1.0.2/istio.yaml']
+  args: ['-O', 'knative/templates/istio.yaml', 'https://raw.githubusercontent.com/knative/serving/release-0.5/third_party/istio-1.0.7/istio.yaml']
 
 # Get the Knative Build manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative-build.yaml', 'https://github.com/knative/build/releases/download/v0.3.0/release.yaml']
+  args: ['-O', 'knative/templates/knative-build.yaml', 'https://github.com/knative/build/releases/download/v0.5.0/build.yaml']
+
+# Get the Knative Build/Serving cluster roles
+- name: 'gcr.io/cloud-builders/wget'
+  args: ['-O', 'knative/templates/knative-build-clusterrole.yaml', 'https://raw.githubusercontent.com/knative/serving/master/third_party/config/build/clusterrole.yaml']
+
 # Get the Knative Serving manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml']
+  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.4.1/serving.yaml']
 
 # Templatize the chart
 - name: 'debian:stable-slim'
@@ -54,7 +59,7 @@ steps:
   - '-c'
   - |
         mkdir repo
-        mv knative-0.3.0.tgz ./repo
+        mv knative-0.4.1.tgz ./repo
 
 # Retrieve the current index
 - name: 'gcr.io/cloud-builders/wget'
@@ -70,20 +75,20 @@ steps:
 
 # Push it to gcs bucket
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', './repo/knative-0.3.0.tgz', 'gs://$PROJECT_ID-charts/knative-0.3.0.tgz']
+  args: ['cp', './repo/knative-0.4.1.tgz', 'gs://$PROJECT_ID-charts/knative-0.4.1.tgz']
 
 # Build the installer
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', '-f', './installer/Dockerfile', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.4.1', '-f', './installer/Dockerfile', '.']
 
 # Tag and push
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.4.1']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', 'gcr.io/$PROJECT_ID/knative-installer:0.3']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.4.1', 'gcr.io/$PROJECT_ID/knative-installer:0.4']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.3']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.4']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.3.0', 'gcr.io/$PROJECT_ID/knative-installer:latest']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.4.1', 'gcr.io/$PROJECT_ID/knative-installer:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:latest']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
         mv Chart.yaml ./knative
         mv values.yaml ./knative
         mv knative-cluster-role.yaml ./knative/templates
+        mv knative-config-domain.yaml ./knative/templates
 
 # Get the Istio 1.0.7 manifest to resolve CVE-2019-9900 and CVE-2019-9901
 - name: 'gcr.io/cloud-builders/wget'
@@ -34,8 +35,8 @@ steps:
   - |
         cat knative/templates/knative-build.yaml knative/templates/knative-serving.yaml > knative/templates/knative.yaml.base
         rm knative/templates/knative-build.yaml knative/templates/knative-serving.yaml
+        sed -i 's/config-domain/config-domain-example/' knative/templates/knative.yaml.base
         sed -i 's/{{/{{ "{{" }}/g' knative/templates/knative.yaml.base
-        sed -i 's/example.com/{{ .Values.domain }}/' knative/templates/knative.yaml.base
         sed -i 's/LoadBalancer/{{ .Values.istioIngressType }}/' knative/templates/istio.yaml
         ./fix-knative.pl knative/templates/knative.yaml.base > knative/templates/knative.yaml
         rm knative/templates/knative.yaml.base

--- a/knative-config-domain.yaml
+++ b/knative-config-domain.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    serving.knative.dev/release: devel
+  name: config-domain
+  namespace: knative-serving
+data:
+  {{ .Values.domain }}: |
+


### PR DESCRIPTION
Perform the initial update of the helm charts to 0.4.1.  There are still two outstanding issues:

1. Additional cluster role bindings need to be introduced between Serving and Build so that the two components can talk to each other.
1. Upstream Knative Serving has redone how configmaps should be maintained including serverless domain names to allow for multiple domain names and staging environments.

Once both of these issues are taken care of, then this should be safe to release.