### PR TITLE
Istio 1.1.13 -> 1.1.15 and throttle memory requirements

### DIFF
--- a/istio-lean.yaml
+++ b/istio-lean.yaml
@@ -1,5 +1,5 @@
 ---
-# istio-lean is based on a modified form of istio-1.1.13
+# istio-lean is based on a modified form of istio-1.1.15
 # PATCH #1: Creating the istio-system namespace.
 apiVersion: v1
 kind: Namespace
@@ -406,7 +406,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-multi
   labels:
-    chart: istio-1.1.13
+    chart: istio-1.1.15
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -597,7 +597,7 @@ spec:
       serviceAccountName: cluster-local-gateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.1.13"
+          image: "docker.io/istio/proxyv2:1.1.15"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 15020
@@ -757,7 +757,7 @@ spec:
       serviceAccountName: istio-ingressgateway-service-account
       containers:
         - name: ingress-sds
-          image: "docker.io/istio/node-agent-k8s:1.1.13"
+          image: "docker.io/istio/node-agent-k8s:1.1.15"
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -781,7 +781,7 @@ spec:
           - name: ingressgatewaysdsudspath
             mountPath: /var/run/ingress_gateway
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.1.13"
+          image: "docker.io/istio/proxyv2:1.1.15"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 15020
@@ -1010,7 +1010,7 @@ spec:
                 - s390x
       containers:
       - name: mixer
-        image: "docker.io/istio/mixer:1.1.13"
+        image: "docker.io/istio/mixer:1.1.15"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 15014
@@ -1054,7 +1054,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: istio-proxy
-        image: "docker.io/istio/proxyv2:1.1.13"
+        image: "docker.io/istio/proxyv2:1.1.15"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091
@@ -1143,7 +1143,7 @@ spec:
       serviceAccountName: istio-pilot-service-account
       containers:
         - name: discovery
-          image: "docker.io/istio/pilot:1.1.13"
+          image: "docker.io/istio/pilot:1.1.15"
           imagePullPolicy: IfNotPresent
           args:
           - "discovery"

--- a/istio-lean.yaml
+++ b/istio-lean.yaml
@@ -829,8 +829,8 @@ spec:
               cpu: 3000m
               memory: 2048Mi
             requests:
-              cpu: 3000m
-              memory: 2048Mi
+              cpu: 100m
+              memory: 128Mi
 
           env:
           - name: POD_NAME
@@ -1035,11 +1035,11 @@ spec:
           value: "6"
         resources:
           limits:
-            cpu: 4800m
-            memory: 4G
+            cpu: 100m
+            memory: 100Mi
           requests:
-            cpu: 1000m
-            memory: 1G
+            cpu: 50m
+            memory: 100Mi
 
         volumeMounts:
         - name: telemetry-adapter-secret
@@ -1187,8 +1187,8 @@ spec:
             value: "1"
           resources:
             requests:
-              cpu: 3000m
-              memory: 2048Mi
+              cpu: 10m
+              memory: 100Mi
 
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
Based on feedback from the Gitlab community, throttle back some of the cpu and memory requirements for istio-proxy and istio-telementry such that the knative components can fit inside an n1-standard-2 system.

In addition, given the amount of time from the initial work, bump up the version of istio used from 1.1.13 -> 1.1.15.