### PR TITLE
Initial support for knative 0.8.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.7.0"
+appVersion: "0.8.1"
 description: A Helm chart for Knative
 name: knative
-version: 0.7.0
+version: 0.8.1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
 
 # Get the Knative Build manifest [deprecated in lieu of Tekton]
 #- name: 'gcr.io/cloud-builders/wget'
-#  args: ['-O', 'knative/templates/knative-build.yaml', 'https://github.com/knative/build/releases/download/v0.7.0/build.yaml']
+#  args: ['-O', 'knative/templates/knative-build.yaml', 'https://github.com/knative/build/releases/download/v0.8.1/build.yaml']
 
 # Get the Knative Build/Serving cluster roles
 #- name: 'gcr.io/cloud-builders/wget'
@@ -24,7 +24,7 @@ steps:
 
 # Get the Knative Serving manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml']
+  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.8.1/serving.yaml']
 
 # Templatize the chart
 - name: 'debian:stable-slim'
@@ -61,7 +61,7 @@ steps:
   - '-c'
   - |
         mkdir repo
-        mv knative-0.7.0.tgz ./repo
+        mv knative-0.8.1.tgz ./repo
 
 # Retrieve the current index
 - name: 'gcr.io/cloud-builders/gsutil'
@@ -81,20 +81,20 @@ steps:
 
 # Push it to gcs bucket
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', './repo/knative-0.7.0.tgz', 'gs://$PROJECT_ID-charts/knative-0.7.0.tgz']
+  args: ['cp', './repo/knative-0.8.1.tgz', 'gs://$PROJECT_ID-charts/knative-0.8.1.tgz']
 
 # Build the installer
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.7.0', '-f', './installer/Dockerfile', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/knative-installer:0.8.1', '-f', './installer/Dockerfile', '.']
 
 # Tag and push
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.7.0']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.8.1']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.7.0', 'gcr.io/$PROJECT_ID/knative-installer:0.7']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.8.1', 'gcr.io/$PROJECT_ID/knative-installer:0.8']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.7']
+  args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:0.8']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.7.0', 'gcr.io/$PROJECT_ID/knative-installer:latest']
+  args: ['tag', 'gcr.io/$PROJECT_ID/knative-installer:0.8.1', 'gcr.io/$PROJECT_ID/knative-installer:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/knative-installer:latest']


### PR DESCRIPTION
Version bump of knative to 0.8.1 from 0.7.  Maintaining the current version of Istio as 1.2 was in early testing at the time of release, and 1.3 is not supported at the time.

Note that testing with Gitlab is inconclusive due to a bug with the current codebase not registering a knative installation.  Biggest risk for this is that prometheus will not be able to utilize the current istio metrics for determining request count.