### PR TITLE
Switch knative serving base file to rely on post k8s 1.14

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,9 @@ steps:
 
 # Get the Knative Serving manifest
 - name: 'gcr.io/cloud-builders/wget'
-  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.9.0/serving.yaml']
+  # TODO: This is a 1 release workaround to force k8s v1.14 support
+  #args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.9.0/serving.yaml']
+  args: ['-O', 'knative/templates/knative-serving.yaml', 'https://github.com/knative/serving/releases/download/v0.9.0/serving-post-1.14.yaml']
 
 # Templatize the chart
 - name: 'debian:stable-slim'

--- a/istio-lean.yaml
+++ b/istio-lean.yaml
@@ -985,7 +985,7 @@ spec:
             cpu: 4800m
             memory: 4G
           requests:
-            cpu: 1000m
+            cpu: 500m
             memory: 1G
 
         volumeMounts:


### PR DESCRIPTION
Based on feedback from Gitlab, there was a request to support the v1alpha1, v1beta1, and v1 endpoints for Knative Serving.  This is only available with k8s releases newer than v1.13.10.  In addition, an update to throttle down the mixer collector cpu requirements was missing from the previous update.