### PR TITLE
Allow for extra environment variables in deployment

### DIFF
--- a/charts/triggermesh/Chart.yaml
+++ b/charts/triggermesh/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart deploying TriggerMesh Open Source Components
 
 type: application
 
-version: 0.4.5
+version: 0.4.6
 
 appVersion: "v1.17.0"

--- a/charts/triggermesh/templates/deployment.yaml
+++ b/charts/triggermesh/templates/deployment.yaml
@@ -203,6 +203,9 @@ spec:
           value: "{{ .Values.image.registry }}/ibmmqtarget-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
         - name: XSLTTRANSFORMATION_IMAGE
           value: "{{ .Values.image.registry }}/xslttransformation-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        {{- with .Values.extraEnv -}}
+        {{ . | toYaml | nindent 8 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9090

--- a/charts/triggermesh/values.yaml
+++ b/charts/triggermesh/values.yaml
@@ -13,6 +13,9 @@ image:
 
 imagePullSecrets: []
 
+# list of name/value pairs to inject as additional environment variables to deployment
+extraEnv: []
+
 rbac:
   create: true
 


### PR DESCRIPTION
This is for instance required if you need to access azure over a http-proxy.

Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>