### PR TITLE
Fix Azure EventHubs source image reference

### DIFF
--- a/charts/triggermesh/Chart.yaml
+++ b/charts/triggermesh/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart deploying TriggerMesh Open Source Components
 
 type: application
 
-version: 0.6.2
+version: 0.6.3
 
 appVersion: "v1.22.0"
 

--- a/charts/triggermesh/templates/deployment.yaml
+++ b/charts/triggermesh/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: AWSSQSSOURCE_IMAGE
               value: "{{ .Values.image.registry }}/awssqssource-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
             - name: AZUREEVENTHUBSSOURCE_IMAGE
-              value: "{{ .Values.image.registry }}/azureeventhubsource-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              value: "{{ .Values.image.registry }}/azureeventhubssource-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
             - name: AZUREIOTHUBSOURCE_IMAGE
               value: "{{ .Values.image.registry }}/azureiothubsource-adapter:{{ .Values.image.tag | default .Chart.AppVersion }}"
             - name: AZUREQUEUESTORAGESOURCE_IMAGE


### PR DESCRIPTION
Missed in https://github.com/triggermesh/charts/pull/180/files#diff-30d71f72ba5ddef0fe0438757bde96fcfb222ee49ce61e12651eb4c632048756

Resolves #183

I'm not familiar with the charts lifecycle, but we may need to re-create the release artifacts after this.
