### PR TITLE
Set service type to explicitly be ClusterIP

### DIFF
--- a/charts/triggermesh/templates/webhook/service.yaml
+++ b/charts/triggermesh/templates/webhook/service.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     {{- include "triggermesh.webhook.labels" . | nindent 4 }}
 spec:
+  type: ClusterIP
   ports:
     - name: https-webhook
       port: 443


### PR DESCRIPTION
I cannot imagine there is any reason this should be unset, or should be a different value other than `ClusterIP`. If there is reason it could change, then this should become a helm value so operators can parameterize.