### PR TITLE
fix(webhook): Define dedicated wehbook podAnnotations

### DIFF
--- a/charts/triggermesh/templates/webhook/deployment.yaml
+++ b/charts/triggermesh/templates/webhook/deployment.yaml
@@ -26,8 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: 'false'
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Use dedicated webhook podAnnotations definition instead of global podAnnotations definition in Triggermesh Helm chart like define in [values.yaml file](https://github.com/triggermesh/charts/blob/main/charts/triggermesh/values.yaml#L59)